### PR TITLE
Update displayed version number

### DIFF
--- a/compiler/main.c
+++ b/compiler/main.c
@@ -83,7 +83,7 @@ int main( int argc, char *argv[] )
         }
         if(strcmp(argv[1],CLI_FLAG_INTERPRETER) == 0)
         {
-            printf("StackVM v0.2.2: welcome.\n");
+            printf("StackVM v0.2.3: welcome.\n");
             printf("Data width: %d.\n", sizeof(DWORD));
             machine_initialize(&machine);
             machine.mode = MACHINE_MODE_INTERPRETER;


### PR DESCRIPTION
The version number in the line "StackVM v0.2.2: welcome." is one version behind. I fixed this.
(I am a total noob at Github so if I am doing this wrong let me know please.)